### PR TITLE
feat(I-5): Helm service-template chart + CD workflow

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -1,0 +1,73 @@
+name: CD Helm Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/cd-helm.yml'
+
+jobs:
+  deploy-staging:
+    name: deploy / staging
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: '3.16.0'
+
+      - name: Set up kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+
+      - name: Deploy services to staging
+        run: |
+          for chart in deploy/helm/*/; do
+            service=$(basename "$chart")
+            # service-template is a reference chart, not a deployable release
+            [ "$service" = "service-template" ] && continue
+            echo "Deploying $service to staging..."
+            helm upgrade --install "$service" "$chart" \
+              --namespace staging \
+              --create-namespace \
+              --set image.tag=${{ github.sha }} \
+              --wait \
+              --timeout 5m
+          done
+
+  deploy-production:
+    name: deploy / production
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: '3.16.0'
+
+      - name: Set up kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+
+      - name: Deploy services to production
+        run: |
+          for chart in deploy/helm/*/; do
+            service=$(basename "$chart")
+            [ "$service" = "service-template" ] && continue
+            echo "Deploying $service to production..."
+            helm upgrade --install "$service" "$chart" \
+              --namespace production \
+              --create-namespace \
+              --set image.tag=${{ github.sha }} \
+              --wait \
+              --timeout 5m
+          done

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -270,6 +270,23 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/api-tracker/files-service:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/api-tracker/files-service:latest
 
+  helm-lint:
+    name: helm / lint
+    runs-on: ubuntu-latest
+    if: >
+      contains(github.event.head_commit.modified, 'deploy/helm') ||
+      contains(github.event.head_commit.added, 'deploy/helm') ||
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: '3.16.0'
+      - name: Lint service-template chart
+        run: helm lint deploy/helm/service-template
+      - name: Template service-template chart
+        run: helm template test-release deploy/helm/service-template
+
   proto:
     name: proto / lint + codegen
     runs-on: ubuntu-latest

--- a/deploy/helm/service-template/Chart.yaml
+++ b/deploy/helm/service-template/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: service-template
+description: Generic Helm chart template for api-tracker backend services
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/deploy/helm/service-template/templates/_helpers.tpl
+++ b/deploy/helm/service-template/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+Expand the name of the release. Used as the primary resource name.
+*/}}
+{{- define "service-template.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Chart name.
+*/}}
+{{- define "service-template.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "service-template.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "service-template.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels used by Deployment and Service to match pods.
+*/}}
+{{- define "service-template.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "service-template.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/helm/service-template/templates/configmap.yaml
+++ b/deploy/helm/service-template/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "service-template.fullname" . }}
+  labels:
+    {{- include "service-template.labels" . | nindent 4 }}
+data: {}

--- a/deploy/helm/service-template/templates/deployment.yaml
+++ b/deploy/helm/service-template/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "service-template.fullname" . }}
+  labels:
+    {{- include "service-template.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "service-template.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "service-template.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ include "service-template.fullname" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.service.grpcPort }}
+              protocol: TCP
+          {{- if or .Values.envFrom.configMapRef .Values.envFrom.secretRef }}
+          envFrom:
+            {{- if .Values.envFrom.configMapRef }}
+            - configMapRef:
+                name: {{ .Values.envFrom.configMapRef }}
+            {{- end }}
+            {{- if .Values.envFrom.secretRef }}
+            - secretRef:
+                name: {{ .Values.envFrom.secretRef }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20

--- a/deploy/helm/service-template/templates/hpa.yaml
+++ b/deploy/helm/service-template/templates/hpa.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "service-template.fullname" . }}
+  labels:
+    {{- include "service-template.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "service-template.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}

--- a/deploy/helm/service-template/templates/ingress.yaml
+++ b/deploy/helm/service-template/templates/ingress.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "service-template.fullname" . }}
+  labels:
+    {{- include "service-template.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "service-template.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/deploy/helm/service-template/templates/secret.yaml
+++ b/deploy/helm/service-template/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "service-template.fullname" . }}
+  labels:
+    {{- include "service-template.labels" . | nindent 4 }}
+type: Opaque
+data: {}

--- a/deploy/helm/service-template/templates/service.yaml
+++ b/deploy/helm/service-template/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "service-template.fullname" . }}
+  labels:
+    {{- include "service-template.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "service-template.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/service-template/templates/servicemonitor.yaml
+++ b/deploy/helm/service-template/templates/servicemonitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "service-template.fullname" . }}
+  labels:
+    {{- include "service-template.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "service-template.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/deploy/helm/service-template/values.yaml
+++ b/deploy/helm/service-template/values.yaml
@@ -1,0 +1,44 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/gaev-tech/api-tracker/service
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  port: 8080
+  grpcPort: 9090
+
+hpa:
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+ingress:
+  enabled: false
+  host: ""
+  path: /
+  annotations: {}
+
+# Inline env vars: list of {name, value} pairs
+env: []
+# - name: FOO
+#   value: bar
+
+# envFrom: reference existing ConfigMap and/or Secret by name
+envFrom:
+  configMapRef: ""  # name of ConfigMap to mount as envFrom; empty = skip
+  secretRef: ""     # name of Secret to mount as envFrom; empty = skip
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  path: /metrics

--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -24,9 +24,9 @@ Kubernetes, observability, CI/CD, масштабирование. Изменяе
 
 ### 1.2. Топология окружений
 
-Минимум два окружения:
-- **staging** — отдельный namespace (или отдельный кластер для изоляции) для интеграционного тестирования.
-- **production** — основная среда.
+Один кластер Kubernetes, два namespace-а:
+- **`staging`** — для интеграционного тестирования. Деплой происходит автоматически после успешного merge в main.
+- **`production`** — основная среда. Деплой требует ручного подтверждения (`environment: production` с required reviewers в GitHub Actions).
 
 Dev-окружение разработчика — локальный Kubernetes (Kind / Minikube / Docker Desktop) либо Docker Compose с минимальным набором зависимостей (Postgres, Kafka, Redis).
 
@@ -177,7 +177,8 @@ Monorepo разделён на верхнем уровне по экосисте
 │
 ├── .github/
 │   └── workflows/
-│       └── ci-backend.yml
+│       ├── ci-backend.yml          # lint, test, build, push images
+│       └── cd-helm.yml             # helm deploy на staging (авто) и production (ручное)
 ├── Makefile
 └── README.md
 ```
@@ -200,8 +201,8 @@ Monorepo разделён на верхнем уровне по экосисте
 4. **Integration-тесты:** поднимаются через docker-compose (Postgres, Kafka).
 5. **Build images:** для изменившихся сервисов. Path-based триггеры (`paths:` в workflow): изменение в `services/workspace/` → собирается только workspace. Image tagging: `ghcr.io/<owner>/<repo>/<service>:<commit-sha>`, плюс `:latest` для главной ветки. Теги branch-name не используются.
 6. **Push в GitHub Container Registry (ghcr.io):** только при мерже в main. В pull request образы собираются (для проверки Dockerfile), но не публикуются. Все Docker-джобы находятся в `.github/workflows/ci-backend.yml` (отдельный файл для Docker не создаётся).
-7. **Deploy на staging** (автоматически после успешного pipeline в main).
-8. **Deploy на production** — ручное подтверждение (`environment: production` с required reviewers).
+7. **Deploy на staging** — автоматически после успешного pipeline в main. Реализован в отдельном workflow `.github/workflows/cd-helm.yml`. Kubeconfig кластера хранится в GitHub Actions Secret `KUBECONFIG_B64` (base64-encoded), на каждом deploy-job декодируется во временный файл.
+8. **Deploy на production** — ручное подтверждение (`environment: production` с required reviewers). Тот же `cd-helm.yml`, отдельный job с `environment: production`.
 
 ### 3.3. Деплой в Kubernetes
 


### PR DESCRIPTION
## Summary

- `deploy/helm/service-template/` — параметризованный эталонный Helm-чарт для всех backend-сервисов: Deployment (RollingUpdate, readiness/liveness пробы, envFrom для ConfigMap/Secret), Service (HTTP 8080 + gRPC 9090), HPA (autoscaling/v2, по CPU), ServiceMonitor (Prometheus Operator), ConfigMap, Secret, Ingress (отключён по умолчанию)
- `.github/workflows/cd-helm.yml` — CD workflow: `deploy-staging` (авто при push в main) → `deploy-production` (ручное подтверждение через `environment: production`); kubeconfig из `KUBECONFIG_B64` secret
- `.github/workflows/ci-backend.yml` — добавлен `helm-lint` job: `helm lint` + `helm template` на каждый PR/push

## Проверка

`helm lint` — 0 failures, `helm template` — корректные манифесты для всех 7 ресурсов.

Closes #5