### PR TITLE
spec: post-impl sync for I-5

### DIFF
--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -206,7 +206,7 @@ Monorepo разделён на верхнем уровне по экосисте
 
 ### 3.3. Деплой в Kubernetes
 
-**Инструмент:** `helm upgrade --install <release> deploy/helm/<service>` из CI-job.
+**Инструмент:** `helm upgrade --install <release> deploy/helm/<service>` из CI-job. Версия Helm: **3.16.0**, устанавливается через `azure/setup-helm@v4` в GitHub Actions.
 
 #### Шаблон чарта (I-5)
 


### PR DESCRIPTION
## Summary

- `architecture-infra.md`: зафиксирована версия Helm 3.16.0 и action `azure/setup-helm@v4` — техническое решение, принятое в I-5, не было отражено в спеке до мержа