### PR TITLE
spec: naming conventions for I-6 PostgreSQL instances

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -381,17 +381,17 @@ State clearly: **"Project Manager (post): [issue #N closed / PR #M merged or clo
 
 After all three post-implementation roles complete:
 
-1. If any spec was updated in post-implementation review, commit it:
+1. If any spec was updated in post-implementation review, commit it on a branch and open a PR:
    ```bash
+   git checkout -b spec/[task-id]-post-impl-sync
    git add specs/
    git commit -m "spec: post-impl sync for [task-id]
 
    - [file]: [what changed]"
+   git push -u origin spec/[task-id]-post-impl-sync
+   gh pr create --title "spec: post-impl sync for [task-id]" --body "..."
    ```
-   Push directly to main (spec-only commit, no code change):
-   ```bash
-   git push origin main
-   ```
+   PM merges the PR (same as all other PRs — never push directly to main).
 
 2. Confirm: all three roles signed off, issue closed, PR merged or closed, no stale PRs.
 

--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -34,6 +34,16 @@ Dev-окружение разработчика — локальный Kubernete
 
 Секреты хранятся в Kubernetes Secret, на старте инжектятся в pods через env / volume. Для боевого управления секретами может использоваться HashiCorp Vault или SealedSecrets — решение откладывается на более поздний этап.
 
+### 1.4. Конвенции именования БД и credentials
+
+**Названия баз данных:** `<service>_db` — например, `identity_db`, `billing_db`, `files_db`, `workspace_db`, `events_db`, `automations_db`.
+
+**Названия ролей:** `<service>_user` — например, `identity_user`, `billing_user`. Каждая роль имеет права только на свою БД (principle of least privilege).
+
+**K8s Secrets с connection strings:** `<service>-db-credentials` — например, `identity-db-credentials`. Содержит ключ `DATABASE_URL` в формате DSN: `postgresql://<user>:<password>@<host>:5432/<dbname>?sslmode=require`.
+
+Сервисы читают `DATABASE_URL` из env-переменной (через `envFrom.secretRef` в Helm-чарте).
+
 ---
 
 ## 2. Наблюдаемость


### PR DESCRIPTION
## Summary

- `architecture-infra.md`: добавлен раздел 1.4 — конвенции именования БД (`<service>_db`), ролей (`<service>_user`), K8s Secrets (`<service>-db-credentials`, ключ `DATABASE_URL` в формате DSN)
- `skills/review/SKILL.md`: исправлен Phase 2 Final — убрана инструкция push directly to main, заменена на branch+PR