### PR TITLE
feat(I-6): PostgreSQL services in docker-compose

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,2 +1,73 @@
-services: {}
-# TODO: I-20 — наполнить: PostgreSQL, Citus, Redis, Kafka, MinIO, все backend-сервисы, api-gateway, frontend
+services:
+
+  # ── PostgreSQL: identity-service ──────────────────────────────────────────
+  postgres-identity:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: identity_db
+      POSTGRES_USER: identity_user
+      POSTGRES_PASSWORD: identity_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-identity-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U identity_user -d identity_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # TODO: I-6 — backup policy настраивается при переходе на K8s/managed PostgreSQL
+
+  # ── PostgreSQL: billing-service ───────────────────────────────────────────
+  postgres-billing:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: billing_db
+      POSTGRES_USER: billing_user
+      POSTGRES_PASSWORD: billing_pass
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-billing-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U billing_user -d billing_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # TODO: I-6 — backup policy настраивается при переходе на K8s/managed PostgreSQL
+
+  # ── PostgreSQL: files-service ─────────────────────────────────────────────
+  postgres-files:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: files_db
+      POSTGRES_USER: files_user
+      POSTGRES_PASSWORD: files_pass
+    ports:
+      - "5434:5432"
+    volumes:
+      - postgres-files-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U files_user -d files_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # TODO: I-6 — backup policy настраивается при переходе на K8s/managed PostgreSQL
+
+  # TODO: I-20 — добавить: Citus (workspace/events/automations), Redis, Kafka, MinIO,
+  #              все backend-сервисы, api-gateway, frontend
+
+volumes:
+  postgres-identity-data:
+  postgres-billing-data:
+  postgres-files-data:
+
+networks:
+  backend:
+    driver: bridge


### PR DESCRIPTION
## Summary

- `deploy/docker-compose.yml`: три PostgreSQL-сервиса (identity, billing, files), каждый в отдельном контейнере `postgres:16-alpine`
  - `postgres-identity` → порт 5432, база `identity_db`, пользователь `identity_user`
  - `postgres-billing` → порт 5433, база `billing_db`, пользователь `billing_user`
  - `postgres-files` → порт 5434, база `files_db`, пользователь `files_user`
- Named volumes для персистентности данных между перезапусками
- Healthcheck через `pg_isready` для корректного `depends_on` у будущих сервисов
- Сеть `backend` для межсервисного взаимодействия
- Backup policy — TODO (настраивается при переходе на K8s/managed)

Closes #6