### PR TITLE
spec: pre-impl review for I-13 (Prometheus + Grafana)

### DIFF
--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -64,6 +64,28 @@ Dev-окружение разработчика — локальный Kubernete
 - Dashboard Kafka: lag по consumer groups (особенно automations-service и events-service).
 - Dashboard по тарифам: распределение пользователей по тарифам, доход, отказы платежей.
 
+**Локальная разработка (docker-compose, I-13):**
+
+Prometheus и Grafana добавляются в `deploy/docker-compose.yml` как обычные сервисы. Конфигурация хранится в `deploy/monitoring/`:
+
+```
+deploy/monitoring/
+├── prometheus.yml              # scrape-конфиг
+└── grafana/
+    ├── provisioning/
+    │   ├── datasources/
+    │   │   └── prometheus.yml  # автоматическое подключение datasource
+    │   └── dashboards/
+    │       └── dashboard.yml   # провайдер дашбордов
+    └── dashboards/
+        └── overview.json       # базовый dashboard
+```
+
+- **Prometheus** слушает `:9090`. Scrape-интервал 15s. В `prometheus.yml` перечислены job'ы для каждого сервиса (`metrics`-endpoint на `/metrics`).
+- **Grafana** слушает `:3000`. Admin-credentials: `admin` / `admin` (dev только). Datasource Prometheus и дашборды подключаются через provisioning при старте.
+
+В K8s — `kube-prometheus-stack` через Helm (после I-2). ServiceMonitor'ы сервисов активируются через `serviceMonitor.enabled: true` в Helm values.
+
 ### 2.2. Ошибки
 
 **Sentry** собирает все unhandled-исключения и HTTP 5xx-ошибки из сервисов через Go SDK. Context обогащается: user_id (если аутентифицирован), request_id, service name.

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -537,8 +537,8 @@ graph TD
 
 - **Тип:** инфраструктура.
 - **Блокеры:** I-2.
-- **Описание:** установить `kube-prometheus-stack`. Настроить Grafana с админ-паролем в Secret. Настроить datasource Prometheus. Импортировать базовые дашборды (K8s-ресурсы, Nginx Ingress).
-- **Критерии готовности:** (1) Grafana доступна через Ingress с TLS. (2) Метрики K8s видны в Prometheus. (3) Базовый dashboard работает.
+- **Описание:** добавить Prometheus и Grafana в `deploy/docker-compose.yml` как сервисы для локальной разработки. Prometheus scrape-конфиг (`prometheus.yml`) — файл в `deploy/monitoring/`. Grafana — с предустановленным datasource Prometheus и базовым dashboard'ом через provisioning (файлы в `deploy/monitoring/grafana/`). В K8s будет `kube-prometheus-stack` (после I-2).
+- **Критерии готовности:** (1) `docker compose up` поднимает Prometheus (:9090) и Grafana (:3000). (2) Prometheus scrape-конфиг валиден и сам Prometheus виден в targets. (3) Grafana открывается с datasource Prometheus, базовый dashboard виден.
 
 ### I-14. Loki + Promtail
 


### PR DESCRIPTION
## Summary
- `architecture-infra.md`: documented docker-compose setup for Prometheus + Grafana — `deploy/monitoring/` layout, ports (:9090, :3000), Grafana provisioning approach, K8s note
- `roadmap.md`: updated I-13 description to reflect docker-compose implementation (kube-prometheus-stack deferred until I-2)

## Pre-implementation review sign-offs
- Product Specialist (pre): passed
- Technical Architect (pre): updated architecture-infra.md + roadmap.md
- Project Manager (pre): passed, issue #13 updated

Closes #13 — tracked via implementation PR