### PR TITLE
spec: pre-impl review for I-14 (Loki + Promtail)

### DIFF
--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -100,11 +100,28 @@ deploy/monitoring/
 
 **Loki + Promtail.**
 - Все сервисы пишут структурированные логи в stdout (JSON-формат).
-- Promtail как DaemonSet на каждой ноде собирает логи pod'ов и отправляет в Loki.
-- Loki индексирует метки (service, pod, severity), сам текст хранит сжатыми chunk'ами.
+- Promtail собирает логи и отправляет в Loki.
+- Loki индексирует метки (service, container, level), сам текст хранит сжатыми chunk'ами.
 - Grafana предоставляет UI для поиска логов (LogQL).
 
 **Стандартные поля в логе:** `timestamp`, `level`, `service`, `request_id`, `user_id`, `message`, `error` (если есть).
+
+**Локальная разработка (docker-compose, I-14):**
+
+Loki и Promtail добавляются в `deploy/docker-compose.yml`. Конфиги хранятся в `deploy/monitoring/`:
+
+```
+deploy/monitoring/
+├── loki-config.yml             # хранилище chunk'ов в filesystem, retention 7d
+├── promtail-config.yml         # pipeline scrape через Docker socket
+...
+```
+
+- **Loki** слушает `:3100`. Хранит логи локально в volume `loki-data`. Retention 7 дней.
+- **Promtail** монтирует Docker socket (`/var/run/docker.sock`) и читает логи всех контейнеров через Docker service discovery. Добавляет метки `container`, `compose_service`, `image`.
+- **Datasource Loki** добавляется в Grafana provisioning (`deploy/monitoring/grafana/provisioning/datasources/loki.yml`).
+
+В K8s — Loki Helm chart + Promtail как DaemonSet (после I-2).
 
 ### 2.4. Request tracing
 

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -544,8 +544,8 @@ graph TD
 
 - **Тип:** инфраструктура.
 - **Блокеры:** I-2.
-- **Описание:** установить Loki и Promtail через Helm. Подключить Loki как datasource в Grafana. Настроить Promtail как DaemonSet — сбор логов всех pod'ов.
-- **Критерии готовности:** (1) Логи любого pod'а доступны в Grafana через LogQL. (2) Фильтрация по label `service` работает.
+- **Описание:** добавить Loki и Promtail в `deploy/docker-compose.yml` как сервисы для локальной разработки. Конфиг Loki (`loki-config.yml`) и Promtail (`promtail-config.yml`) — в `deploy/monitoring/`. Promtail читает логи Docker-контейнеров через Docker socket. Datasource Loki добавить в Grafana provisioning. В K8s будет Loki Helm chart + Promtail DaemonSet (после I-2).
+- **Критерии готовности:** (1) `docker compose up` поднимает Loki (:3100) и Promtail. (2) Логи docker-compose сервисов видны в Grafana через LogQL. (3) Datasource Loki настроен в Grafana.
 
 ### I-15. Sentry
 


### PR DESCRIPTION
## Summary
- `roadmap.md`: updated I-14 description to docker-compose approach (K8s/DaemonSet deferred to after I-2)
- `architecture-infra.md`: section 2.3 — docker-compose Loki (:3100) + Promtail via Docker socket, config file layout, Grafana datasource provisioning

Pre-implementation review sign-offs:
- Product Specialist (pre): passed
- Technical Architect (pre): updated roadmap.md + architecture-infra.md
- Project Manager (pre): passed, issue #14 updated