### PR TITLE
feat(I-14): Loki + Promtail in docker-compose

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -162,6 +162,30 @@ services:
       postgres-files:
         condition: service_healthy
 
+  # ── Loki ──────────────────────────────────────────────────────────────────
+  loki:
+    image: grafana/loki:3.1.0
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki-data:/loki
+    networks:
+      - backend
+    command: -config.file=/etc/loki/local-config.yaml
+
+  # ── Promtail ───────────────────────────────────────────────────────────────
+  promtail:
+    image: grafana/promtail:2.9.8
+    volumes:
+      - ./monitoring/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    networks:
+      - backend
+    depends_on:
+      - loki
+
   # TODO: I-20 — добавить: Citus (workspace/events/automations), Redis, Kafka, MinIO,
   #              все backend-сервисы, frontend
 
@@ -171,6 +195,7 @@ volumes:
   postgres-files-data:
   prometheus-data:
   grafana-data:
+  loki-data:
 
 networks:
   backend:

--- a/deploy/monitoring/grafana/provisioning/datasources/loki.yml
+++ b/deploy/monitoring/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false

--- a/deploy/monitoring/loki-config.yml
+++ b/deploy/monitoring/loki-config.yml
@@ -1,0 +1,42 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h  # 7 days
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem

--- a/deploy/monitoring/promtail-config.yml
+++ b/deploy/monitoring/promtail-config.yml
@@ -1,0 +1,44 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+        filters:
+          - name: status
+            values: [running]
+    relabel_configs:
+      # Use Docker container name as the instance label
+      - source_labels: [__meta_docker_container_name]
+        regex: /(.*)
+        target_label: container
+      # Use docker-compose service name
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: compose_service
+      # Use image name
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+      # Drop containers without a compose service label (non-compose containers)
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        action: keep
+        regex: .+
+    pipeline_stages:
+      # Attempt to parse JSON logs; if not JSON, keep raw message
+      - json:
+          expressions:
+            level: level
+            msg: message
+            service: service
+            request_id: request_id
+      - labels:
+          level:
+          service:


### PR DESCRIPTION
## Summary
- Loki 3.1.0 (:3100) — filesystem storage, 7d retention, schema v13
- Promtail 2.9.8 — Docker socket discovery, labels: `container`, `compose_service`, JSON pipeline stage for structured logs
- Grafana datasource Loki added via provisioning
- `loki-data` volume for persistence

## Test plan
- [ ] `docker compose up` starts loki and promtail without errors
- [ ] Loki at http://localhost:3100/ready returns `ready`
- [ ] Grafana → Explore → Loki datasource → `{compose_project="deploy"}` returns logs

Closes #14