### PR TITLE
fix(ci): cd-helm triggers after CI Backend completes

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -1,16 +1,16 @@
 name: CD Helm Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI Backend"]
+    types: [completed]
     branches: [main]
-    paths:
-      - 'deploy/helm/**'
-      - '.github/workflows/cd-helm.yml'
 
 jobs:
   deploy-staging:
     name: deploy / staging
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: staging
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,22 @@
-.PHONY: build test lint help
+.PHONY: build up down test lint help
 
-SERVICES := identity-service workspace-service automations-service events-service billing-service files-service
+COMPOSE := docker compose -f deploy/docker-compose.yml
+GO_RUN  := docker run --rm -v $(shell pwd)/backend:/app -w /app golang:1.23-alpine
 
-build: ## Build all backend services
-	@for svc in $(SERVICES); do \
-		echo "==> build $$svc"; \
-		cd backend/services/$$svc && go build ./... && cd ../../..; \
-	done
+build: ## Build all Docker images
+	$(COMPOSE) build
 
-test: ## Run tests for all backend services
-	@for svc in $(SERVICES); do \
-		echo "==> test $$svc"; \
-		cd backend/services/$$svc && go test ./... && cd ../../..; \
-	done
+up: ## Start all services
+	$(COMPOSE) up -d
 
-lint: ## Run go vet for all backend services
-	@for svc in $(SERVICES); do \
-		echo "==> vet $$svc"; \
-		cd backend/services/$$svc && go vet ./... && cd ../../..; \
-	done
+down: ## Stop all services
+	$(COMPOSE) down
+
+test: ## Run tests for all services inside Docker
+	$(GO_RUN) go test ./...
+
+lint: ## Run go vet for all services inside Docker
+	$(GO_RUN) go vet ./...
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
## Summary

- Replaced `on: push` trigger in `cd-helm.yml` with `on: workflow_run` so Helm deploy waits for CI Backend to finish
- Added `if: conclusion == 'success'` guard — deploy only runs when all images are built and pushed to ghcr.io
- Updated `Makefile` to use `docker compose` commands instead of raw Go calls

## Why

Previously `cd-helm.yml` and `ci-backend.yml` triggered in parallel on push to main. Helm could deploy before Docker images were available in ghcr.io, causing Kubernetes to fail pulling the image.

Closes #4