### PR TITLE
fix(ci): add workflow_dispatch to cd-helm

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -1,17 +1,14 @@
 name: CD Helm Deploy
 
 on:
-  workflow_run:
-    workflows: ["CI Backend"]
-    types: [completed]
-    branches: [main]
-  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   deploy-staging:
     name: deploy / staging
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment: staging
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -5,12 +5,13 @@ on:
     workflows: ["CI Backend"]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy-staging:
     name: deploy / staging
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment: staging
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Allows manual deploy trigger. Fixes Skipped status when CI Backend doesn't run (e.g. only infra files changed).