### PR TITLE
feat(I-3): Nginx Ingress + cert-manager + TLS

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -6,9 +6,56 @@ on:
       - 'v*'
 
 jobs:
+  setup-cluster:
+    name: setup / cluster
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: '3.16.0'
+
+      - name: Set up kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+
+      - name: Install ingress-nginx
+        run: |
+          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo update
+          helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+            --namespace ingress-nginx \
+            --create-namespace \
+            --version 4.11.3 \
+            --set controller.service.type=LoadBalancer \
+            --wait \
+            --timeout 5m
+
+      - name: Install cert-manager
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
+          helm upgrade --install cert-manager jetstack/cert-manager \
+            --namespace cert-manager \
+            --create-namespace \
+            --version v1.16.2 \
+            --set installCRDs=true \
+            --wait \
+            --timeout 5m
+
+      - name: Wait for cert-manager webhooks
+        run: kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s
+
+      - name: Apply ClusterIssuers
+        run: kubectl apply -f deploy/k8s/
+
   deploy-staging:
     name: deploy / staging
     runs-on: ubuntu-latest
+    needs: setup-cluster
     environment: staging
     steps:
       - uses: actions/checkout@v4

--- a/deploy/k8s/cluster-issuer-prod.yml
+++ b/deploy/k8s/cluster-issuer-prod.yml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: gaev93@ya.ru
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/deploy/k8s/cluster-issuer-staging.yml
+++ b/deploy/k8s/cluster-issuer-staging.yml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: gaev93@ya.ru
+    privateKeySecretRef:
+      name: letsencrypt-staging-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -41,7 +41,13 @@ annotations:
   nginx.ingress.kubernetes.io/ssl-redirect: "true"
 ```
 
-**Домены:** настраиваются через `ingress.host` в Helm values каждого сервиса. Публичный Ingress создаётся только для api-gateway.
+**Установка:** ingress-nginx и cert-manager устанавливаются через Helm в GitHub Actions (job `setup-cluster` в `cd-helm.yml`), который запускается перед деплоем сервисов. Использует `helm upgrade --install` — идемпотентно, безопасно запускать при каждом деплое.
+
+**Домен:** `apitracker.ru`. API доступен на `api.apitracker.ru`. Let's Encrypt email: `gaev93@ya.ru`.
+
+**ClusterIssuer-манифесты** хранятся в `deploy/k8s/` и применяются через `kubectl apply` в том же job `setup-cluster` после установки cert-manager.
+
+**Публичный Ingress** создаётся только для api-gateway (`api.apitracker.ru`). Остальные сервисы общаются внутри кластера.
 
 ### 1.2. Топология окружений
 

--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -22,6 +22,27 @@ Kubernetes, observability, CI/CD, масштабирование. Изменяе
 - **Sentry:** self-hosted через Helm либо облачный Sentry.
 - **MinIO** (если не managed S3): через MinIO Operator.
 
+### 1.1.1. Nginx Ingress Controller + cert-manager
+
+**Nginx Ingress Controller** устанавливается через официальный Helm chart (`ingress-nginx`). Слушает порты 80 и 443 снаружи кластера.
+
+**cert-manager** устанавливается через Helm chart (`jetstack/cert-manager`). Управляет TLS-сертификатами через Let's Encrypt.
+
+**Challenge type:** HTTP-01 (для отдельных доменов без wildcard). Для HTTP-01 не нужен доступ к DNS API — cert-manager отвечает на challenge через Ingress.
+
+**ClusterIssuer** создаётся в namespace `cert-manager`:
+- `letsencrypt-staging` — для тестирования (использует staging ACME сервер Let's Encrypt, не выдаёт доверенный сертификат, но нет rate limit'ов).
+- `letsencrypt-prod` — для production (выдаёт доверенный сертификат, rate limit: 5 сертификатов на домен в неделю).
+
+**Аннотации Ingress:**
+```yaml
+annotations:
+  cert-manager.io/cluster-issuer: letsencrypt-prod
+  nginx.ingress.kubernetes.io/ssl-redirect: "true"
+```
+
+**Домены:** настраиваются через `ingress.host` в Helm values каждого сервиса. Публичный Ingress создаётся только для api-gateway.
+
 ### 1.2. Топология окружений
 
 Один кластер Kubernetes, два namespace-а:


### PR DESCRIPTION
## Summary

- Добавлен job `setup-cluster` в `cd-helm.yml` — запускается перед деплоем сервисов
- Устанавливает ingress-nginx 4.11.3 и cert-manager v1.16.2 через Helm (идемпотентно)
- Применяет ClusterIssuer для Let's Encrypt staging и production
- Challenge type: HTTP-01 через `ingressClassName: nginx`
- Домен: `apitracker.ru`, email: `gaev93@ya.ru`

## Test plan
- [ ] Создать тег `v0.1.2`, убедиться что job `setup-cluster` проходит зелёным
- [ ] Проверить на сервере: `kubectl get clusterissuer`
- [ ] Проверить: `kubectl get pods -n ingress-nginx` и `kubectl get pods -n cert-manager`

Closes #3