### PR TITLE
feat(I-19): Nginx API Gateway Helm chart

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -270,6 +270,29 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/api-tracker/files-service:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/api-tracker/files-service:latest
 
+  docker-api-gateway:
+    name: docker / api-gateway
+    runs-on: ubuntu-latest
+    if: >
+      contains(github.event.head_commit.modified, 'backend/api-gateway') ||
+      contains(github.event.head_commit.added, 'backend/api-gateway') ||
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: backend/api-gateway
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/api-tracker/api-gateway:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/api-tracker/api-gateway:latest
+
   helm-lint:
     name: helm / lint
     runs-on: ubuntu-latest
@@ -286,6 +309,10 @@ jobs:
         run: helm lint deploy/helm/service-template
       - name: Template service-template chart
         run: helm template test-release deploy/helm/service-template
+      - name: Lint api-gateway chart
+        run: helm lint deploy/helm/api-gateway
+      - name: Template api-gateway chart
+        run: helm template test-release deploy/helm/api-gateway
 
   proto:
     name: proto / lint + codegen

--- a/deploy/helm/api-gateway/Chart.yaml
+++ b/deploy/helm/api-gateway/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: api-gateway
+description: Nginx API Gateway for api-tracker
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/deploy/helm/api-gateway/templates/configmap.yaml
+++ b/deploy/helm/api-gateway/templates/configmap.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-nginx-conf
+  labels:
+    app: {{ .Release.Name }}
+data:
+  nginx.conf: |
+    worker_processes auto;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        # ── Rate limiting zones ──────────────────────────────────────────────
+        # per-PAT: key = Authorization header value (unique per token)
+        limit_req_zone $http_authorization zone=per_pat:10m rate=100r/s;
+        # per-IP: for unauthenticated endpoints (register, login)
+        limit_req_zone $binary_remote_addr zone=per_ip:10m rate=10r/s;
+
+        # ── Request ID ───────────────────────────────────────────────────────
+        map $http_x_request_id $req_id {
+            ""      $request_id;
+            default $http_x_request_id;
+        }
+
+        # ── Server ───────────────────────────────────────────────────────────
+        server {
+            listen 80;
+            server_name _;
+
+            # K3s kube-dns resolver — defers upstream DNS resolution to
+            # request time (avoids startup failure when upstream pods are not
+            # yet running)
+            resolver 10.43.0.10 valid=30s ipv6=off;
+
+            # Propagate / generate request ID through the chain
+            proxy_set_header X-Request-ID $req_id;
+
+            # TODO: F-3 — PAT validation via auth_request
+            # auth_request /internal/auth/validate;
+            # auth_request_set $x_user_id $upstream_http_x_user_id;
+            # auth_request_set $x_parent_user_id $upstream_http_x_parent_user_id;
+            # auth_request_set $x_is_active $upstream_http_x_is_active;
+
+            # Placeholder headers until F-3 implements auth_request
+            proxy_set_header X-User-Id "";
+            proxy_set_header X-Parent-User-Id "";
+            proxy_set_header X-Is-Active "";
+
+            # ── Health check ─────────────────────────────────────────────────
+            location = /healthz {
+                access_log off;
+                return 200 "ok\n";
+                add_header Content-Type text/plain;
+            }
+
+            # ── Nginx metrics (internal — K3s pod CIDR only) ──────────────────
+            location = /stub_status {
+                stub_status;
+                access_log off;
+                allow 10.42.0.0/16;
+                deny all;
+            }
+
+            # ── Auth / Identity — unauthenticated (per-IP rate limit) ─────────
+            location ~ ^/auth/ {
+                limit_req zone=per_ip burst=20 nodelay;
+                set $upstream identity-service:8080;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $host;
+            }
+
+            # ── Identity — authenticated (per-PAT rate limit) ──────────────────
+            location ~ ^/(users|pats|managed-users)/ {
+                limit_req zone=per_pat burst=200 nodelay;
+                set $upstream identity-service:8080;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $host;
+            }
+
+            # ── Workspace ──────────────────────────────────────────────────────
+            location ~ ^/(tasks|projects|teams|invitations|ownership-transfers)/ {
+                limit_req zone=per_pat burst=200 nodelay;
+                set $upstream workspace-service:8080;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $host;
+            }
+
+            # ── Billing ────────────────────────────────────────────────────────
+            location ~ ^/(tariffs|payments)/ {
+                limit_req zone=per_pat burst=200 nodelay;
+                set $upstream billing-service:8080;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $host;
+            }
+
+            # ── Files ──────────────────────────────────────────────────────────
+            location ~ ^/files/ {
+                limit_req zone=per_pat burst=200 nodelay;
+                set $upstream files-service:8080;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $host;
+            }
+
+            # ── Events: WebSocket (sticky routing by PAT token query param) ────
+            location = /events/stream {
+                limit_req zone=per_pat burst=50 nodelay;
+                set $upstream_ws events-service:8080;
+                proxy_pass http://$upstream_ws;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_set_header Host $host;
+                proxy_read_timeout 3600s;
+            }
+
+            # ── Events: regular HTTP ────────────────────────────────────────────
+            location ~ ^/events {
+                limit_req zone=per_pat burst=200 nodelay;
+                set $upstream events-service:8080;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $host;
+            }
+        }
+    }

--- a/deploy/helm/api-gateway/templates/deployment.yaml
+++ b/deploy/helm/api-gateway/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: nginx
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: {{ .Release.Name }}-nginx-conf

--- a/deploy/helm/api-gateway/templates/ingress.yaml
+++ b/deploy/helm/api-gateway/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}
+                port:
+                  name: http
+{{- end }}

--- a/deploy/helm/api-gateway/templates/service.yaml
+++ b/deploy/helm/api-gateway/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+  selector:
+    app: {{ .Release.Name }}

--- a/deploy/helm/api-gateway/values.yaml
+++ b/deploy/helm/api-gateway/values.yaml
@@ -1,0 +1,31 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/gaev-tech/api-tracker/api-gateway
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  port: 80
+
+ingress:
+  enabled: true
+  host: api.apitracker.ru
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  tls:
+    secretName: api-gateway-tls
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+hpa:
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70


### PR DESCRIPTION
## Summary

- Helm chart `deploy/helm/api-gateway/` — nginx pod с маршрутизацией ко всем backend-сервисам
- nginx.conf адаптирован для K8s: resolver `10.43.0.10` (K3s kube-dns), stub_status ограничен pod CIDR `10.42.0.0/16`
- Ingress `api.apitracker.ru` с TLS через `letsencrypt-prod`
- CI job `docker-api-gateway` — build+push образа при изменении `backend/api-gateway/**`
- PAT-валидация заглушена (`// TODO: F-3`)

## Test plan
- [ ] Создать тег `v0.1.5` — убедиться что api-gateway деплоится в staging и production
- [ ] Проверить: `curl https://api.apitracker.ru/healthz` → `ok`
- [ ] Проверить: `kubectl get certificate -n staging` → Ready

Closes #19