### PR TITLE
fix(ci): wait for ingress-nginx webhook before deploy

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -48,6 +48,13 @@ jobs:
             --wait \
             --timeout 5m
 
+      - name: Wait for ingress-nginx webhook endpoint
+        run: |
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=120s
+
       - name: Wait for cert-manager webhooks
         run: kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s
 


### PR DESCRIPTION
## Summary
- Adds explicit `kubectl wait` for ingress-nginx controller pod readiness after Helm install
- Prevents race condition where `deploy-staging` tries to create Ingress before admission webhook endpoint is available

## Root cause
`helm upgrade --install ingress-nginx --wait` waits for pod Running state, but the admission webhook endpoint registration may lag behind, causing `no endpoints available for service "ingress-nginx-controller-admission"` on the next job.

Closes #155