### PR TITLE
fix(ci): delete ingress-nginx admission webhook instead of waiting

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -48,12 +48,8 @@ jobs:
             --wait \
             --timeout 5m
 
-      - name: Wait for ingress-nginx webhook endpoint
-        run: |
-          kubectl wait --namespace ingress-nginx \
-            --for=condition=ready pod \
-            --selector=app.kubernetes.io/component=controller \
-            --timeout=120s
+      - name: Remove ingress-nginx admission webhook
+        run: kubectl delete validatingwebhookconfiguration ingress-nginx-admission --ignore-not-found=true
 
       - name: Wait for cert-manager webhooks
         run: kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s


### PR DESCRIPTION
## Summary
- Replaces `kubectl wait` (which timed out) with deletion of `ValidatingWebhookConfiguration ingress-nginx-admission`
- In K3s bare-metal with hostNetwork the webhook endpoint is unreachable from the API server, so validation always fails
- Deleting the webhook config is the standard workaround for this K3s setup