### PR TITLE
fix(ci): delete ingress webhook + helm dry-run on PRs

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+      - 'deploy/k8s/**'
+      - '.github/workflows/cd-helm.yml'
 
 jobs:
   setup-cluster:
@@ -61,7 +66,7 @@ jobs:
     name: deploy / staging
     runs-on: ubuntu-latest
     needs: setup-cluster
-    environment: staging
+    environment: ${{ github.event_name == 'pull_request' && 'staging-dry-run' || 'staging' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -77,23 +82,25 @@ jobs:
 
       - name: Deploy services to staging
         run: |
+          DRY_RUN=${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
           for chart in deploy/helm/*/; do
             service=$(basename "$chart")
-            # service-template is a reference chart, not a deployable release
             [ "$service" = "service-template" ] && continue
-            echo "Deploying $service to staging..."
+            echo "Deploying $service to staging${DRY_RUN:+ (dry-run)}..."
             helm upgrade --install "$service" "$chart" \
               --namespace staging \
               --create-namespace \
               --set image.tag=${{ github.sha }} \
               --wait \
-              --timeout 5m
+              --timeout 5m \
+              $DRY_RUN
           done
 
   deploy-production:
     name: deploy / production
     runs-on: ubuntu-latest
     needs: deploy-staging
+    if: github.event_name != 'pull_request'
     environment: production
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -48,12 +48,8 @@ jobs:
             --wait \
             --timeout 5m
 
-      - name: Wait for ingress-nginx webhook endpoint
-        run: |
-          kubectl wait --namespace ingress-nginx \
-            --for=condition=ready pod \
-            --selector=app.kubernetes.io/component=controller \
-            --timeout=120s
+      - name: Remove ingress-nginx admission webhook
+        run: kubectl delete validatingwebhookconfiguration ingress-nginx-admission --ignore-not-found=true
 
       - name: Wait for cert-manager webhooks
         run: kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s


### PR DESCRIPTION
## Summary
- Удаляет `ValidatingWebhookConfiguration ingress-nginx-admission` после установки ingress-nginx — в K3s с hostNetwork webhook endpoint недоступен и блокирует деплой Ingress-ресурсов
- `cd-helm.yml` триггерится на `pull_request` (изменения в `deploy/helm/**`, `deploy/k8s/**`, `.github/workflows/cd-helm.yml`)
- На PR: `setup-cluster` полностью + `deploy-staging --dry-run` — валидирует чарты против кластера без применения
- `deploy-production` пропускается на PR
- На тег `v*`: реальный деплой staging → production как прежде