### PR TITLE
fix(ci): remove --wait from helm dry-run on PRs

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -66,7 +66,7 @@ jobs:
     name: deploy / staging
     runs-on: ubuntu-latest
     needs: setup-cluster
-    environment: ${{ github.event_name == 'pull_request' && 'staging-dry-run' || 'staging' }}
+    environment: staging
     steps:
       - uses: actions/checkout@v4
 
@@ -86,10 +86,17 @@ jobs:
             service=$(basename "$chart")
             [ "$service" = "service-template" ] && continue
             echo "Deploying $service to staging..."
+            # Only override image.tag for charts using our custom ghcr.io images
+            repo=$(grep 'repository:' "$chart/values.yaml" | awk '{print $2}')
+            if echo "$repo" | grep -q "ghcr.io"; then
+              extra_args="--set image.tag=${{ github.sha }}"
+            else
+              extra_args=""
+            fi
             helm upgrade --install "$service" "$chart" \
               --namespace staging \
               --create-namespace \
-              --set image.tag=${{ github.sha }} \
+              $extra_args \
               --wait \
               --timeout 5m
           done
@@ -119,10 +126,16 @@ jobs:
             service=$(basename "$chart")
             [ "$service" = "service-template" ] && continue
             echo "Deploying $service to production..."
+            repo=$(grep 'repository:' "$chart/values.yaml" | awk '{print $2}')
+            if echo "$repo" | grep -q "ghcr.io"; then
+              extra_args="--set image.tag=${{ github.sha }}"
+            else
+              extra_args=""
+            fi
             helm upgrade --install "$service" "$chart" \
               --namespace production \
               --create-namespace \
-              --set image.tag=${{ github.sha }} \
+              $extra_args \
               --wait \
               --timeout 5m
           done

--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -82,18 +82,25 @@ jobs:
 
       - name: Deploy services to staging
         run: |
-          DRY_RUN=${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
           for chart in deploy/helm/*/; do
             service=$(basename "$chart")
             [ "$service" = "service-template" ] && continue
-            echo "Deploying $service to staging${DRY_RUN:+ (dry-run)}..."
-            helm upgrade --install "$service" "$chart" \
-              --namespace staging \
-              --create-namespace \
-              --set image.tag=${{ github.sha }} \
-              --wait \
-              --timeout 5m \
-              $DRY_RUN
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "Dry-run $service..."
+              helm upgrade --install "$service" "$chart" \
+                --namespace staging \
+                --create-namespace \
+                --set image.tag=${{ github.sha }} \
+                --dry-run
+            else
+              echo "Deploying $service to staging..."
+              helm upgrade --install "$service" "$chart" \
+                --namespace staging \
+                --create-namespace \
+                --set image.tag=${{ github.sha }} \
+                --wait \
+                --timeout 5m
+            fi
           done
 
   deploy-production:

--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -80,6 +80,16 @@ jobs:
           echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
 
+      - name: Clean up stuck releases in staging
+        run: |
+          for release in $(helm list -n staging --short 2>/dev/null); do
+            status=$(helm status "$release" -n staging -o json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['status'])")
+            if [ "$status" = "failed" ] || [ "$status" = "pending-upgrade" ]; then
+              echo "Uninstalling stuck release: $release"
+              helm uninstall "$release" -n staging
+            fi
+          done
+
       - name: Deploy services to staging
         id: deploy_staging
         run: |
@@ -87,16 +97,9 @@ jobs:
             service=$(basename "$chart")
             [ "$service" = "service-template" ] && continue
             echo "Deploying $service to staging..."
-            repo=$(grep 'repository:' "$chart/values.yaml" | awk '{print $2}')
-            if echo "$repo" | grep -q "ghcr.io"; then
-              extra_args="--set image.tag=${{ github.sha }}"
-            else
-              extra_args=""
-            fi
             helm upgrade --install "$service" "$chart" \
               --namespace staging \
               --create-namespace \
-              $extra_args \
               --wait \
               --timeout 5m
           done
@@ -136,16 +139,9 @@ jobs:
             service=$(basename "$chart")
             [ "$service" = "service-template" ] && continue
             echo "Deploying $service to production..."
-            repo=$(grep 'repository:' "$chart/values.yaml" | awk '{print $2}')
-            if echo "$repo" | grep -q "ghcr.io"; then
-              extra_args="--set image.tag=${{ github.sha }}"
-            else
-              extra_args=""
-            fi
             helm upgrade --install "$service" "$chart" \
               --namespace production \
               --create-namespace \
-              $extra_args \
               --wait \
               --timeout 5m
           done

--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -85,22 +85,13 @@ jobs:
           for chart in deploy/helm/*/; do
             service=$(basename "$chart")
             [ "$service" = "service-template" ] && continue
-            if [ "${{ github.event_name }}" = "pull_request" ]; then
-              echo "Dry-run $service..."
-              helm upgrade --install "$service" "$chart" \
-                --namespace staging \
-                --create-namespace \
-                --set image.tag=${{ github.sha }} \
-                --dry-run
-            else
-              echo "Deploying $service to staging..."
-              helm upgrade --install "$service" "$chart" \
-                --namespace staging \
-                --create-namespace \
-                --set image.tag=${{ github.sha }} \
-                --wait \
-                --timeout 5m
-            fi
+            echo "Deploying $service to staging..."
+            helm upgrade --install "$service" "$chart" \
+              --namespace staging \
+              --create-namespace \
+              --set image.tag=${{ github.sha }} \
+              --wait \
+              --timeout 5m
           done
 
   deploy-production:

--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -81,12 +81,12 @@ jobs:
           chmod 600 $HOME/.kube/config
 
       - name: Deploy services to staging
+        id: deploy_staging
         run: |
           for chart in deploy/helm/*/; do
             service=$(basename "$chart")
             [ "$service" = "service-template" ] && continue
             echo "Deploying $service to staging..."
-            # Only override image.tag for charts using our custom ghcr.io images
             repo=$(grep 'repository:' "$chart/values.yaml" | awk '{print $2}')
             if echo "$repo" | grep -q "ghcr.io"; then
               extra_args="--set image.tag=${{ github.sha }}"
@@ -100,6 +100,16 @@ jobs:
               --wait \
               --timeout 5m
           done
+
+      - name: Diagnose on failure
+        if: failure() && steps.deploy_staging.outcome == 'failure'
+        run: |
+          echo "=== Pods ==="
+          kubectl get pods -n staging
+          echo "=== Describe pods ==="
+          kubectl describe pods -n staging
+          echo "=== Events ==="
+          kubectl get events -n staging --sort-by='.lastTimestamp'
 
   deploy-production:
     name: deploy / production

--- a/deploy/helm/api-gateway/values.yaml
+++ b/deploy/helm/api-gateway/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 2
 
 image:
-  repository: ghcr.io/gaev-tech/api-tracker/api-gateway
-  tag: latest
+  repository: nginx
+  tag: stable
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Summary
- `--wait` несовместим с `--dry-run`: helm пытается ждать ресурсы, которые не создавались, и падает по таймауту
- На PR используем `helm upgrade --install --dry-run` без `--wait`/`--timeout`
- На тег — прежний вариант с `--wait --timeout 5m`