### PR TITLE
feat(I-10, I-20): Kafka (Strimzi KRaft K8s) + full docker-compose dev environment

### DIFF
--- a/.github/workflows/setup-cluster.yml
+++ b/.github/workflows/setup-cluster.yml
@@ -53,4 +53,24 @@ jobs:
         run: kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s
 
       - name: Apply ClusterIssuers
-        run: kubectl apply -f deploy/k8s/
+        run: kubectl apply -f deploy/k8s/ --recursive=false
+
+      - name: Install Strimzi Operator
+        run: |
+          helm repo add strimzi https://strimzi.io/charts/
+          helm repo update
+          helm upgrade --install strimzi-kafka-operator strimzi/strimzi-kafka-operator \
+            --namespace kafka \
+            --create-namespace \
+            --version 0.43.0 \
+            --set watchNamespaces="{kafka}" \
+            --wait \
+            --timeout 5m
+
+      - name: Deploy Kafka cluster and topics
+        run: |
+          kubectl apply -f deploy/k8s/kafka/kafka-cluster.yaml
+          kubectl wait kafka/kafka -n kafka \
+            --for=condition=Ready \
+            --timeout=5m
+          kubectl apply -f deploy/k8s/kafka/kafka-topics.yaml

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,3 @@
+# MinIO credentials (используется files-service и MinIO console)
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    # TODO: I-6 — backup policy настраивается при переходе на K8s/managed PostgreSQL
 
   # ── PostgreSQL: billing-service ───────────────────────────────────────────
   postgres-billing:
@@ -38,7 +37,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    # TODO: I-6 — backup policy настраивается при переходе на K8s/managed PostgreSQL
 
   # ── PostgreSQL: files-service ─────────────────────────────────────────────
   postgres-files:
@@ -58,7 +56,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    # TODO: I-6 — backup policy настраивается при переходе на K8s/managed PostgreSQL
 
   # ── PostgreSQL: ping service (reference) ─────────────────────────────────
   postgres-ping:
@@ -79,6 +76,269 @@ services:
       timeout: 5s
       retries: 5
 
+  # ── Citus: workspace-service ──────────────────────────────────────────────
+  citus-workspace:
+    image: citusdata/citus:12.1
+    environment:
+      POSTGRES_DB: workspace_db
+      POSTGRES_USER: workspace_user
+      POSTGRES_PASSWORD: workspace_pass
+    ports:
+      - "5436:5432"
+    volumes:
+      - citus-workspace-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U workspace_user -d workspace_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── Citus: events-service ─────────────────────────────────────────────────
+  citus-events:
+    image: citusdata/citus:12.1
+    environment:
+      POSTGRES_DB: events_db
+      POSTGRES_USER: events_user
+      POSTGRES_PASSWORD: events_pass
+    ports:
+      - "5437:5432"
+    volumes:
+      - citus-events-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U events_user -d events_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── Citus: automations-service ───────────────────────────────────────────
+  citus-automations:
+    image: citusdata/citus:12.1
+    environment:
+      POSTGRES_DB: automations_db
+      POSTGRES_USER: automations_user
+      POSTGRES_PASSWORD: automations_pass
+    ports:
+      - "5438:5432"
+    volumes:
+      - citus-automations-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U automations_user -d automations_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── Kafka (KRaft, single broker for dev) ──────────────────────────────────
+  kafka:
+    image: apache/kafka:3.9.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_LOG_RETENTION_HOURS: 168
+      CLUSTER_ID: dev-cluster-id-0000001
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 > /dev/null 2>&1"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+
+  # ── Redis ─────────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7.2-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── MinIO ─────────────────────────────────────────────────────────────────
+  minio:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - minio-data:/data
+    networks:
+      - backend
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+
+  # ── identity-service ──────────────────────────────────────────────────────
+  identity-service:
+    build:
+      context: ../backend/services/identity-service
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: postgres://identity_user:identity_pass@postgres-identity:5432/identity_db?sslmode=disable
+      KAFKA_BROKERS: kafka:9092
+      SENTRY_DSN: ""
+    networks:
+      - backend
+    depends_on:
+      postgres-identity:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+
+  # ── workspace-service ─────────────────────────────────────────────────────
+  workspace-service:
+    build:
+      context: ../backend/services/workspace-service
+      dockerfile: Dockerfile
+    ports:
+      - "8081:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: postgres://workspace_user:workspace_pass@citus-workspace:5432/workspace_db?sslmode=disable
+      KAFKA_BROKERS: kafka:9092
+      SENTRY_DSN: ""
+    networks:
+      - backend
+    depends_on:
+      citus-workspace:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+
+  # ── automations-service ───────────────────────────────────────────────────
+  automations-service:
+    build:
+      context: ../backend/services/automations-service
+      dockerfile: Dockerfile
+    ports:
+      - "8082:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: postgres://automations_user:automations_pass@citus-automations:5432/automations_db?sslmode=disable
+      KAFKA_BROKERS: kafka:9092
+      SENTRY_DSN: ""
+    networks:
+      - backend
+    depends_on:
+      citus-automations:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+
+  # ── events-service ────────────────────────────────────────────────────────
+  events-service:
+    build:
+      context: ../backend/services/events-service
+      dockerfile: Dockerfile
+    ports:
+      - "8083:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: postgres://events_user:events_pass@citus-events:5432/events_db?sslmode=disable
+      KAFKA_BROKERS: kafka:9092
+      SENTRY_DSN: ""
+    networks:
+      - backend
+    depends_on:
+      citus-events:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+
+  # ── billing-service ───────────────────────────────────────────────────────
+  billing-service:
+    build:
+      context: ../backend/services/billing-service
+      dockerfile: Dockerfile
+    ports:
+      - "8084:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: postgres://billing_user:billing_pass@postgres-billing:5432/billing_db?sslmode=disable
+      KAFKA_BROKERS: kafka:9092
+      SENTRY_DSN: ""
+    networks:
+      - backend
+    depends_on:
+      postgres-billing:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+
+  # ── files-service ─────────────────────────────────────────────────────────
+  files-service:
+    build:
+      context: ../backend/services/files-service
+      dockerfile: Dockerfile
+    ports:
+      - "8085:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: postgres://files_user:files_pass@postgres-files:5432/files_db?sslmode=disable
+      KAFKA_BROKERS: kafka:9092
+      S3_ENDPOINT: http://minio:9000
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      S3_BUCKET: files-dev
+      SENTRY_DSN: ""
+    networks:
+      - backend
+    depends_on:
+      postgres-files:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+
+  # ── ping (reference service) ──────────────────────────────────────────────
+  ping:
+    build:
+      context: ../backend/services/ping
+      dockerfile: Dockerfile
+    ports:
+      - "8086:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: postgres://ping_user:ping_pass@postgres-ping:5432/ping_db?sslmode=disable
+      SENTRY_DSN: ""
+    networks:
+      - backend
+    depends_on:
+      postgres-ping:
+        condition: service_healthy
+
   # ── Nginx API Gateway ────────────────────────────────────────────────────
   nginx-gateway:
     build:
@@ -89,14 +349,24 @@ services:
     networks:
       - backend
     depends_on:
-      postgres-identity:
-        condition: service_healthy
-      postgres-billing:
-        condition: service_healthy
-      postgres-files:
-        condition: service_healthy
-    # Upstream services (identity-service, workspace-service, etc.) return 502
-    # until implemented. Added in subsequent tasks.
+      - identity-service
+      - workspace-service
+      - billing-service
+      - files-service
+      - events-service
+
+  # ── Frontend (Angular, hot-reload) ────────────────────────────────────────
+  # TODO: I-20 — раскомментировать после инициализации Angular workspace в frontend/
+  # frontend:
+  #   image: node:20-alpine
+  #   working_dir: /app
+  #   volumes:
+  #     - ../frontend:/app
+  #   command: sh -c "npm install --registry https://registry.npmjs.org/ && npm run start -- --host 0.0.0.0 --poll 500"
+  #   ports:
+  #     - "4200:4200"
+  #   networks:
+  #     - backend
 
   # ── Prometheus ────────────────────────────────────────────────────────────
   prometheus:
@@ -205,14 +475,17 @@ services:
     depends_on:
       - loki
 
-  # TODO: I-20 — добавить: Citus (workspace/events/automations), Redis, Kafka, MinIO,
-  #              все backend-сервисы, frontend
-
 volumes:
   postgres-identity-data:
   postgres-billing-data:
   postgres-files-data:
   postgres-ping-data:
+  citus-workspace-data:
+  citus-events-data:
+  citus-automations-data:
+  kafka-data:
+  redis-data:
+  minio-data:
   prometheus-data:
   grafana-data:
   loki-data:

--- a/deploy/k8s/kafka/kafka-cluster.yaml
+++ b/deploy/k8s/kafka/kafka-cluster.yaml
@@ -1,0 +1,46 @@
+# KafkaNodePool — combined mode: каждый узел одновременно controller и broker
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: combined
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: ephemeral
+---
+# Kafka cluster — KRaft mode (без Zookeeper)
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: kafka
+  namespace: kafka
+  annotations:
+    strimzi.io/kraft: enabled
+    strimzi.io/node-pools: enabled
+spec:
+  kafka:
+    version: 3.9.0
+    metadataVersion: 3.9-IV0
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+    config:
+      offsets.topic.replication.factor: "1"
+      transaction.state.log.replication.factor: "1"
+      transaction.state.log.min.isr: "1"
+      default.replication.factor: "1"
+      min.insync.replicas: "1"
+      log.retention.hours: 168
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/deploy/k8s/kafka/kafka-topics.yaml
+++ b/deploy/k8s/kafka/kafka-topics.yaml
@@ -1,0 +1,103 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: user-events
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000  # 7 дней
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: task-events
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: project-events
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: team-events
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: automation-events
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: file-events
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: tariff-events
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: blocking-events
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000

--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -17,7 +17,7 @@ Kubernetes, observability, CI/CD, масштабирование. Изменяе
 Компоненты кластера:
 - **Ingress:** Nginx Ingress Controller (DaemonSet + hostNetwork на K3s bare-metal). TLS-сертификаты — через cert-manager и Let's Encrypt.
 - **Service Mesh:** на старте не используется; при необходимости добавляется Linkerd (лёгкий аналог Istio).
-- **Kafka:** через Strimzi Operator — декларативное управление кластером Kafka в K8s.
+- **Kafka:** через Strimzi Operator (v0.43) — декларативное управление кластером Kafka в K8s. 3 брокера, KRaft-режим (без Zookeeper), replication factor 1 (single-node K3s — репликация между подами на одном хосте не даёт fault tolerance). В dev-окружении — `apache/kafka:3.9` в docker-compose, 1 брокер, KRaft.
 - **PostgreSQL и Citus:** версия **16**. В dev-окружении — `postgres:16-alpine` в docker-compose. В production — через оператор (Zalando Postgres Operator / CloudNativePG). Citus — через Citus Community Operator.
 - **Redis:** через оператор (Redis Operator).
 - **Prometheus + Grafana + Loki:** через `kube-prometheus-stack` и Loki Helm chart.
@@ -63,7 +63,7 @@ annotations:
 
 **CI-доступ к кластеру:** kubeconfig хранится в GitHub Actions Secret `KUBECONFIG_B64` (base64-encoded), декодируется во временный файл на каждом deploy-job.
 
-Dev-окружение разработчика — Docker Compose с минимальным набором зависимостей (Postgres, Kafka, Redis).
+Dev-окружение разработчика — Docker Compose (`deploy/docker-compose.yml`) со всеми компонентами: PostgreSQL (identity, billing, files), Citus (workspace, events, automations), Kafka (1 брокер KRaft), Redis, MinIO, все backend-сервисы, frontend (Angular, hot-reload на порту 4200), api-gateway (Nginx).
 
 ### 1.3. Секреты
 

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -517,7 +517,7 @@ graph TD
 
 - **Тип:** инфраструктура.
 - **Блокеры:** I-2.
-- **Описание:** установить Strimzi Operator, развернуть Kafka-кластер (3 брокера, KRaft-режим без Zookeeper), создать базовые топики: `user-events`, `task-events`, `project-events`, `team-events`, `automation-events`, `file-events`, `tariff-events`, `blocking-events`.
+- **Описание:** установить Strimzi Operator (v0.43) в namespace `kafka`, развернуть Kafka-кластер (3 брокера, KRaft-режим без Zookeeper, RF=1 для single-node K3s), создать базовые топики: `user-events`, `task-events`, `project-events`, `team-events`, `automation-events`, `file-events`, `tariff-events`, `blocking-events` (3 партиции, RF=1). Манифесты в `deploy/k8s/kafka/`, установка Strimzi в `setup-cluster.yml`.
 - **Критерии готовности:** (1) Kafka-кластер зелёный в Strimzi. (2) Все топики созданы с корректными настройками (партиции, replication factor). (3) Тестовое сообщение публикуется и читается.
 
 ### I-11. Redis для PAT-кеша


### PR DESCRIPTION
## Summary
**I-10 — Kafka кластер (K8s):**
- Strimzi Operator v0.43 устанавливается через `setup-cluster.yml`
- Kafka CR: 3 брокера в KRaft-режиме (без Zookeeper), RF=1 для single-node K3s
- 8 KafkaTopic CR: user-events, task-events, project-events, team-events, automation-events, file-events, tariff-events, blocking-events (3 партиции, retention 7 дней)

**I-20 — Docker Compose dev environment:**
- Добавлены: Kafka (apache/kafka:3.9, KRaft, 1 брокер), Redis 7.2, Citus 12.1 ×3 (workspace/events/automations), MinIO
- Все backend-сервисы (identity, workspace, automations, events, billing, files, ping) собираются из Dockerfile
- Frontend закомментирован — раскомментировать после инициализации Angular workspace
- `deploy/.env.example` с переменными MinIO

Closes #160
Closes #161