### PR TITLE
fix(ci): move buf.yaml to repo root to fix PACKAGE_DIRECTORY_MATCH

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -330,6 +330,7 @@ jobs:
           format: false
           breaking: false
           push: false
+          pr_comment: false
       - name: buf lint
         run: buf lint
       - name: Install Go codegen plugins

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -326,15 +326,17 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           version: '1.68.3'
-          lint: true
+          lint: false
+          format: false
           breaking: false
           push: false
+      - name: buf lint
+        run: buf lint
       - name: Install Go codegen plugins
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
       - name: Run buf generate
-        working-directory: contracts/proto
-        run: buf generate
+        run: buf generate --template contracts/proto/buf.gen.yaml contracts/proto
       - name: Check generated files are up to date
         run: git diff --exit-code contracts/proto

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -337,6 +337,7 @@ jobs:
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Run buf generate
         run: buf generate --template contracts/proto/buf.gen.yaml contracts/proto
       - name: Check generated files are up to date

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,6 +1,6 @@
 version: v2
 modules:
-  - path: .
+  - path: contracts/proto
 lint:
   use:
     - STANDARD

--- a/contracts/proto/ping/v1/ping.proto
+++ b/contracts/proto/ping/v1/ping.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-
+// Reference service proto for testing CI pipeline.
 package ping.v1;
 
 option go_package = "github.com/gaev-tech/api-tracker/contracts/proto/ping/gen;pingv1";


### PR DESCRIPTION
## Summary
- Moved `buf.yaml` from `contracts/proto/` to repo root with `path: contracts/proto`
- `buf-action` runs from repo root; with the old location it resolved paths as `contracts/proto/ping/v1` instead of `ping/v1`, failing `PACKAGE_DIRECTORY_MATCH`
- Disabled built-in lint in buf-action and run `buf lint` as a separate step (action ignores `inputs` param)
- Updated `buf generate` to pass template and module path explicitly