### PR TITLE
feat(I-7,I-8,I-9,I-11,I-12): Citus (CNPG), Redis Operator, MinIO Operator

### DIFF
--- a/.github/workflows/setup-cluster.yml
+++ b/.github/workflows/setup-cluster.yml
@@ -75,6 +75,60 @@ jobs:
             --timeout=5m
           kubectl apply -f deploy/k8s/kafka/kafka-topics.yaml
 
+      - name: Install CloudNativePG (CNPG) Operator
+        run: |
+          helm repo add cnpg https://cloudnative-pg.github.io/charts
+          helm repo update
+          helm upgrade --install cnpg cnpg/cloudnative-pg \
+            --namespace cnpg-system \
+            --create-namespace \
+            --version 0.23.0 \
+            --wait \
+            --timeout 5m
+
+      - name: Create Citus DB credentials secrets in production
+        run: |
+          kubectl create secret generic workspace-db-credentials \
+            --from-literal=username=workspace_user \
+            --from-literal=password=${{ secrets.CITUS_WORKSPACE_PASSWORD }} \
+            --namespace production \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          kubectl create secret generic events-db-credentials \
+            --from-literal=username=events_user \
+            --from-literal=password=${{ secrets.CITUS_EVENTS_PASSWORD }} \
+            --namespace production \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          kubectl create secret generic automations-db-credentials \
+            --from-literal=username=automations_user \
+            --from-literal=password=${{ secrets.CITUS_AUTOMATIONS_PASSWORD }} \
+            --namespace production \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy Citus clusters
+        run: |
+          kubectl apply -f deploy/k8s/citus/workspace.yaml -n production
+          kubectl apply -f deploy/k8s/citus/events.yaml -n production
+          kubectl apply -f deploy/k8s/citus/automations.yaml -n production
+          kubectl wait cluster/citus-workspace-coordinator -n production \
+            --for=condition=Ready --timeout=5m
+          kubectl wait cluster/citus-events-coordinator -n production \
+            --for=condition=Ready --timeout=5m
+          kubectl wait cluster/citus-automations-coordinator -n production \
+            --for=condition=Ready --timeout=5m
+
+      - name: Install OT-Container-Kit Redis Operator
+        run: |
+          helm repo add ot-helm https://ot-container-kit.github.io/helm-charts/
+          helm repo update
+          helm upgrade --install redis-operator ot-helm/redis-operator \
+            --namespace ot-operators \
+            --create-namespace \
+            --version 0.15.1 \
+            --wait \
+            --timeout 5m
+
       - name: Create Redis credentials secret in production
         run: |
           kubectl create secret generic redis-credentials \
@@ -85,4 +139,30 @@ jobs:
       - name: Deploy Redis to production
         run: |
           kubectl apply -f deploy/k8s/redis/redis.yaml -n production
-          kubectl rollout status deployment/redis -n production --timeout=2m
+          kubectl rollout status statefulset/redis-standalone -n production --timeout=2m
+
+      - name: Install MinIO Operator
+        run: |
+          helm repo add minio-operator https://operator.min.io
+          helm repo update
+          helm upgrade --install minio-operator minio-operator/operator \
+            --namespace minio-operator \
+            --create-namespace \
+            --version 6.0.4 \
+            --wait \
+            --timeout 5m
+
+      - name: Create MinIO credentials secret
+        run: |
+          CONFIG_ENV="export MINIO_ROOT_USER=${{ secrets.MINIO_ROOT_USER }}\nexport MINIO_ROOT_PASSWORD=${{ secrets.MINIO_ROOT_PASSWORD }}"
+          kubectl create namespace minio --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create secret generic minio-credentials \
+            --from-literal=config.env="$(printf "$CONFIG_ENV")" \
+            --namespace minio \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy MinIO Tenant
+        run: |
+          kubectl apply -f deploy/k8s/minio/tenant.yaml
+          kubectl wait tenant/minio -n minio \
+            --for=condition=Initialized --timeout=5m

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,8 +1,15 @@
-# MinIO credentials (используется files-service и MinIO console)
+# MinIO credentials (K8s: GitHub Actions secrets → K8s Secret minio-credentials)
+# files-service подключается через S3_ENDPOINT=http://minio.minio:80, S3_BUCKET=files-prod
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 
 # Redis credentials (K8s: GitHub Actions secret REDIS_PASSWORD → K8s Secret redis-credentials)
-# Сервисы подключаются через REDIS_URL=redis://:password@redis:6379/0
+# Сервисы подключаются через REDIS_URL=redis://:password@redis-standalone:6379/0
 # В docker-compose Redis работает без пароля (dev-окружение)
 REDIS_PASSWORD=
+
+# Citus credentials (K8s: GitHub Actions secrets → K8s Secrets *-db-credentials)
+# Формат: postgresql://<user>:<password>@<host>:5432/<db>?sslmode=require
+CITUS_WORKSPACE_PASSWORD=
+CITUS_EVENTS_PASSWORD=
+CITUS_AUTOMATIONS_PASSWORD=

--- a/deploy/k8s/citus/automations.yaml
+++ b/deploy/k8s/citus/automations.yaml
@@ -1,0 +1,88 @@
+# Citus coordinator for automations-service
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: citus-automations-coordinator
+spec:
+  instances: 1
+  postgresql:
+    parameters:
+      shared_preload_libraries: "citus"
+  bootstrap:
+    initdb:
+      database: automations_db
+      owner: automations_user
+      secret:
+        name: automations-db-credentials
+  storage:
+    storageClass: local-path
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+---
+# Citus workers for automations-service (3 instances)
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: citus-automations-workers
+spec:
+  instances: 3
+  postgresql:
+    parameters:
+      shared_preload_libraries: "citus"
+  bootstrap:
+    initdb:
+      database: automations_db
+      owner: automations_user
+      secret:
+        name: automations-db-credentials
+  storage:
+    storageClass: local-path
+    size: 10Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+---
+# Job to register workers with coordinator
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: citus-automations-register-workers
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: register
+          image: postgres:16-alpine
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: automations-db-credentials
+                  key: password
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              COORD=citus-automations-coordinator-rw
+              USER=automations_user
+              DB=automations_db
+              until pg_isready -h $COORD -U $USER -d $DB; do sleep 2; done
+              for i in 0 1 2; do
+                WORKER="citus-automations-workers-$i.citus-automations-workers-r"
+                psql -h $COORD -U $USER -d $DB \
+                  -c "SELECT citus_add_node('$WORKER', 5432);" || true
+              done
+              psql -h $COORD -U $USER -d $DB \
+                -c "SELECT * FROM citus_get_active_worker_nodes();"

--- a/deploy/k8s/citus/events.yaml
+++ b/deploy/k8s/citus/events.yaml
@@ -1,0 +1,88 @@
+# Citus coordinator for events-service
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: citus-events-coordinator
+spec:
+  instances: 1
+  postgresql:
+    parameters:
+      shared_preload_libraries: "citus"
+  bootstrap:
+    initdb:
+      database: events_db
+      owner: events_user
+      secret:
+        name: events-db-credentials
+  storage:
+    storageClass: local-path
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+---
+# Citus workers for events-service (3 instances)
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: citus-events-workers
+spec:
+  instances: 3
+  postgresql:
+    parameters:
+      shared_preload_libraries: "citus"
+  bootstrap:
+    initdb:
+      database: events_db
+      owner: events_user
+      secret:
+        name: events-db-credentials
+  storage:
+    storageClass: local-path
+    size: 10Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+---
+# Job to register workers with coordinator
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: citus-events-register-workers
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: register
+          image: postgres:16-alpine
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: events-db-credentials
+                  key: password
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              COORD=citus-events-coordinator-rw
+              USER=events_user
+              DB=events_db
+              until pg_isready -h $COORD -U $USER -d $DB; do sleep 2; done
+              for i in 0 1 2; do
+                WORKER="citus-events-workers-$i.citus-events-workers-r"
+                psql -h $COORD -U $USER -d $DB \
+                  -c "SELECT citus_add_node('$WORKER', 5432);" || true
+              done
+              psql -h $COORD -U $USER -d $DB \
+                -c "SELECT * FROM citus_get_active_worker_nodes();"

--- a/deploy/k8s/citus/workspace.yaml
+++ b/deploy/k8s/citus/workspace.yaml
@@ -1,0 +1,90 @@
+# Citus coordinator for workspace-service
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: citus-workspace-coordinator
+spec:
+  instances: 1
+  postgresql:
+    parameters:
+      shared_preload_libraries: "citus"
+  bootstrap:
+    initdb:
+      database: workspace_db
+      owner: workspace_user
+      secret:
+        name: workspace-db-credentials
+  storage:
+    storageClass: local-path
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+---
+# Citus workers for workspace-service (3 instances)
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: citus-workspace-workers
+spec:
+  instances: 3
+  postgresql:
+    parameters:
+      shared_preload_libraries: "citus"
+  bootstrap:
+    initdb:
+      database: workspace_db
+      owner: workspace_user
+      secret:
+        name: workspace-db-credentials
+  storage:
+    storageClass: local-path
+    size: 10Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+---
+# Job to register workers with coordinator
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: citus-workspace-register-workers
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: register
+          image: postgres:16-alpine
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-db-credentials
+                  key: password
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              COORD=citus-workspace-coordinator-rw
+              USER=workspace_user
+              DB=workspace_db
+              # Wait for coordinator
+              until pg_isready -h $COORD -U $USER -d $DB; do sleep 2; done
+              # Register each worker
+              for i in 0 1 2; do
+                WORKER="citus-workspace-workers-$i.citus-workspace-workers-r"
+                psql -h $COORD -U $USER -d $DB \
+                  -c "SELECT citus_add_node('$WORKER', 5432);" || true
+              done
+              psql -h $COORD -U $USER -d $DB \
+                -c "SELECT * FROM citus_get_active_worker_nodes();"

--- a/deploy/k8s/minio/tenant.yaml
+++ b/deploy/k8s/minio/tenant.yaml
@@ -1,0 +1,72 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+  configuration:
+    name: minio-credentials
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 1
+      volumeClaimTemplate:
+        spec:
+          storageClassName: local-path
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 20Gi
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+  requestAutoCert: false
+---
+# Job to create files-prod bucket
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-create-bucket
+  namespace: minio
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: config.env
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              # Wait for MinIO to be ready
+              until mc alias set local http://minio.minio:80 \
+                $(grep MINIO_ROOT_USER /tmp/config | cut -d= -f2) \
+                $(grep MINIO_ROOT_PASSWORD /tmp/config | cut -d= -f2) 2>/dev/null; do
+                sleep 3
+              done
+              mc mb local/files-prod --ignore-existing
+              # Lifecycle: delete soft-deleted files after 30 days
+              mc ilm add --expiry-days 30 local/files-prod
+              echo "Bucket files-prod created successfully"
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config
+              subPath: config.env
+      volumes:
+        - name: config
+          secret:
+            secretName: minio-credentials

--- a/deploy/k8s/redis/redis.yaml
+++ b/deploy/k8s/redis/redis.yaml
@@ -1,87 +1,29 @@
-apiVersion: v1
-kind: PersistentVolumeClaim
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: Redis
 metadata:
-  name: redis-data
+  name: redis-standalone
 spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: local-path
-  resources:
-    requests:
-      storage: 1Gi
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: redis
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: redis
-  template:
-    metadata:
-      labels:
-        app: redis
-    spec:
-      containers:
-        - name: redis
-          image: redis:7.2-alpine
-          args:
-            - redis-server
-            - --requirepass
-            - $(REDIS_PASSWORD)
-            - --appendonly
-            - "yes"
-            - --dir
-            - /data
-          env:
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: redis-credentials
-                  key: password
-          ports:
-            - containerPort: 6379
-          volumeMounts:
-            - name: data
-              mountPath: /data
-          livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - redis-cli -a "$REDIS_PASSWORD" ping | grep PONG
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - redis-cli -a "$REDIS_PASSWORD" ping | grep PONG
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          resources:
-            requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 256Mi
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: redis-data
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: redis
-spec:
-  selector:
-    app: redis
-  ports:
-    - port: 6379
-      targetPort: 6379
-  type: ClusterIP
+  kubernetesConfig:
+    image: redis:7.2-alpine
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+    redisSecret:
+      name: redis-credentials
+      key: password
+  storage:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: local-path
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  redisExporter:
+    enabled: false

--- a/specs/architecture-infra.md
+++ b/specs/architecture-infra.md
@@ -18,11 +18,11 @@ Kubernetes, observability, CI/CD, масштабирование. Изменяе
 - **Ingress:** Nginx Ingress Controller (DaemonSet + hostNetwork на K3s bare-metal). TLS-сертификаты — через cert-manager и Let's Encrypt.
 - **Service Mesh:** на старте не используется; при необходимости добавляется Linkerd (лёгкий аналог Istio).
 - **Kafka:** через Strimzi Operator (v0.43) — декларативное управление кластером Kafka в K8s. 3 брокера, KRaft-режим (без Zookeeper), replication factor 1 (single-node K3s — репликация между подами на одном хосте не даёт fault tolerance). В dev-окружении — `apache/kafka:3.9` в docker-compose, 1 брокер, KRaft.
-- **PostgreSQL и Citus:** версия **16**. В dev-окружении — `postgres:16-alpine` в docker-compose. В production — через оператор (Zalando Postgres Operator / CloudNativePG). Citus — через Citus Community Operator.
-- **Redis:** plain K8s manifests (Deployment + Service + PVC) в namespace `production`. Auth через K8s Secret `redis-credentials`.
+- **PostgreSQL и Citus:** версия **16**. В dev-окружении — `postgres:16-alpine` / `citusdata/citus:12.1` в docker-compose. В production — PostgreSQL через CloudNativePG (CNPG) оператор. Citus-кластеры (workspace, events, automations) — через CloudNativePG с расширением Citus: 1 coordinator + 3 workers на кластер. Регистрация workers — Job с `citus_add_node()`.
+- **Redis:** через OT-Container-Kit Redis Operator (`ot-helm/redis-operator`). Standalone-режим, 1 pod. Auth через Secret `redis-credentials`.
 - **Prometheus + Grafana + Loki:** через `kube-prometheus-stack` и Loki Helm chart.
 - **Sentry:** self-hosted через Helm либо облачный Sentry.
-- **MinIO** (если не managed S3): через MinIO Operator.
+- **MinIO:** через официальный MinIO Operator. Tenant с 1 сервером, 1 volume. Bucket `files-prod` создаётся через Job с `mc`.
 
 ### 1.1.1. Nginx Ingress Controller + cert-manager
 

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -496,22 +496,22 @@ graph TD
 
 - **Тип:** инфраструктура.
 - **Блокеры:** I-2.
-- **Описание:** развернуть Citus-кластер (1 coordinator + 3 worker-nodes для начала) через Citus Community Operator или managed-решение. Создать базу `workspace`.
-- **Критерии готовности:** (1) `SELECT * FROM citus_get_active_worker_nodes()` возвращает 3 ноды. (2) Создание distributed-таблицы работает. (3) Backup policy настроена.
+- **Описание:** развернуть Citus-кластер для workspace-service через CloudNativePG (CNPG) оператор. 1 coordinator Cluster + 1 workers Cluster (3 instances). Расширение Citus через `shared_preload_libraries`. Регистрация workers — Job с `citus_add_node()`. База `workspace_db`, роль `workspace_user`. Credentials в K8s Secret `workspace-db-credentials`.
+- **Критерии готовности:** (1) `SELECT * FROM citus_get_active_worker_nodes()` возвращает 3 ноды. (2) Создание distributed-таблицы работает.
 
 ### I-8. Citus-кластер для events-service
 
 - **Тип:** инфраструктура.
 - **Блокеры:** I-2.
-- **Описание:** аналогично I-7, отдельный Citus-кластер для events-service. Настройка партицирования таблицы `events` по `created_at`.
-- **Критерии готовности:** (1) Кластер работает. (2) Создание партиций автоматизировано через pg_partman или аналог.
+- **Описание:** аналогично I-7, отдельный Citus-кластер для events-service через CNPG. 1 coordinator + 3 workers. База `events_db`, роль `events_user`. Credentials в K8s Secret `events-db-credentials`.
+- **Критерии готовности:** (1) Кластер работает, 3 worker-ноды зарегистрированы. (2) Создание distributed-таблицы работает.
 
 ### I-9. Citus-кластер для automations-service
 
 - **Тип:** инфраструктура.
 - **Блокеры:** I-2.
-- **Описание:** аналогично I-7, отдельный Citus-кластер для automations-service.
-- **Критерии готовности:** (1) Кластер работает. (2) Backup policy настроена.
+- **Описание:** аналогично I-7, отдельный Citus-кластер для automations-service через CNPG. 1 coordinator + 3 workers. База `automations_db`, роль `automations_user`. Credentials в K8s Secret `automations-db-credentials`.
+- **Критерии готовности:** (1) Кластер работает, 3 worker-ноды зарегистрированы. (2) Создание distributed-таблицы работает.
 
 ### I-10. Kafka-кластер
 
@@ -524,14 +524,14 @@ graph TD
 
 - **Тип:** инфраструктура.
 - **Блокеры:** I-2.
-- **Описание:** развернуть Redis через plain K8s manifests (Deployment + Service + PVC) в namespace `production`. Persistence через PersistentVolumeClaim. Auth: пароль из K8s Secret `redis-credentials`, создаётся в setup-cluster.yml из GitHub Actions secret `REDIS_PASSWORD`. В docker-compose Redis уже присутствует (без auth, dev-окружение). Сервисы api-gateway и identity-service подключаются через `REDIS_URL=redis://:password@redis:6379/0`.
+- **Описание:** развернуть Redis через OT-Container-Kit Redis Operator (standalone-режим) в namespace `production`. Auth через K8s Secret `redis-credentials` (ключ `password`) из GitHub Actions secret `REDIS_PASSWORD`. В docker-compose Redis уже присутствует (без auth, dev-окружение). Сервисы api-gateway и identity-service подключаются через `REDIS_URL=redis://:password@redis-standalone:6379/0`.
 - **Критерии готовности:** (1) Redis отвечает на PING в namespace production. (2) Подключение из pod'а работает.
 
 ### I-12. S3-совместимое хранилище
 
 - **Тип:** инфраструктура.
 - **Блокеры:** I-2.
-- **Описание:** подключить облачное S3 или развернуть MinIO через оператор. Создать bucket `files-prod`. Настроить IAM-доступ, lifecycle-политики (удаление soft-deleted файлов через 30 дней).
+- **Описание:** развернуть MinIO через официальный MinIO Operator. Tenant с 1 сервером, 1 volume (PVC). Bucket `files-prod` создаётся Job'ом с `mc`. Credentials (`MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`) из GitHub Actions secrets → K8s Secret `minio-credentials`. files-service подключается через `S3_ENDPOINT=http://minio:80`, `S3_BUCKET=files-prod`.
 - **Критерии готовности:** (1) Доступ по S3-API из кластера работает. (2) Bucket-политики настроены. (3) Lifecycle-правила активны.
 
 ### I-13. Prometheus + Grafana


### PR DESCRIPTION
## Summary

- **I-7/I-8/I-9**: Citus clusters for workspace/events/automations via CloudNativePG operator — 1 coordinator + 3 workers per cluster, Job to register workers via `citus_add_node()`
- **I-11**: Redis migrated from plain K8s manifests to OT-Container-Kit Redis Operator (standalone mode)
- **I-12**: MinIO via official MinIO Operator — Tenant with 1 server, 20Gi PVC, Job to create `files-prod` bucket with 30-day lifecycle policy

## New GitHub Actions secrets required

| Secret | Used by |
|--------|---------|
| `CITUS_WORKSPACE_PASSWORD` | workspace-db-credentials |
| `CITUS_EVENTS_PASSWORD` | events-db-credentials |
| `CITUS_AUTOMATIONS_PASSWORD` | automations-db-credentials |
| `MINIO_ROOT_USER` | minio-credentials |
| `MINIO_ROOT_PASSWORD` | minio-credentials |

(`REDIS_PASSWORD` already exists from I-11)

## Files

- `deploy/k8s/citus/workspace.yaml` — coordinator + workers + register Job
- `deploy/k8s/citus/events.yaml` — same for events
- `deploy/k8s/citus/automations.yaml` — same for automations
- `deploy/k8s/minio/tenant.yaml` — MinIO Tenant + bucket Job
- `deploy/k8s/redis/redis.yaml` — Redis CR (OT-Container-Kit)
- `.github/workflows/setup-cluster.yml` — install operators, create secrets, apply manifests

Closes #7
Closes #8
Closes #9
Closes #12