### PR TITLE
fix(F-1): disable ServiceMonitor until Prometheus Operator is installed

### DIFF
--- a/deploy/helm/identity-service/values.yaml
+++ b/deploy/helm/identity-service/values.yaml
@@ -47,6 +47,6 @@ resources:
     memory: 512Mi
 
 serviceMonitor:
-  enabled: true
+  enabled: false
   interval: 30s
   path: /metrics


### PR DESCRIPTION
## Summary
- `serviceMonitor.enabled` set to `false` in `identity-service/values.yaml`
- Helm install was failing with `no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"` because Prometheus Operator CRDs are not yet installed in the cluster
- ServiceMonitor will be re-enabled when the observability stack is deployed as part of a future infra task