### PR TITLE
fix(F-1): disable ServiceMonitor + add deploy diagnostics

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -330,3 +330,19 @@ jobs:
               --wait \
               --timeout 5m
           done
+
+      - name: Diagnose failed pods
+        if: failure()
+        run: |
+          echo "=== Pods ==="
+          kubectl get pods -n production -o wide
+          echo ""
+          echo "=== Events ==="
+          kubectl get events -n production --sort-by='.lastTimestamp' | tail -30
+          echo ""
+          for pod in $(kubectl get pods -n production --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "=== describe: $pod ==="
+            kubectl describe pod "$pod" -n production
+            echo "=== logs: $pod ==="
+            kubectl logs "$pod" -n production --previous 2>/dev/null || kubectl logs "$pod" -n production 2>/dev/null || echo "(no logs)"
+          done

--- a/deploy/helm/identity-service/values.yaml
+++ b/deploy/helm/identity-service/values.yaml
@@ -47,6 +47,6 @@ resources:
     memory: 512Mi
 
 serviceMonitor:
-  enabled: true
+  enabled: false
   interval: 30s
   path: /metrics


### PR DESCRIPTION
## Summary
- Disable `ServiceMonitor` for `identity-service` until Prometheus Operator is installed (`serviceMonitor.enabled: false`)
- Add `Diagnose failed pods` step to the deploy job — runs on failure and outputs pod state, cluster events, `describe`, and logs for non-Running pods

## Test plan
- [ ] CI passes on main after merge
- [ ] On next deploy failure, `Diagnose failed pods` step shows pod state and logs