### PR TITLE
fix(F-1): embed migrations into identity-service binary

### DIFF
--- a/backend/services/identity-service/cmd/main.go
+++ b/backend/services/identity-service/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gaev-tech/api-tracker/backend/pkg/sentry"
 	identityinternal "github.com/gaev-tech/api-tracker/backend/services/identity-service/internal"
 	"github.com/gaev-tech/api-tracker/backend/services/identity-service/internal/auth"
+	migrationsfs "github.com/gaev-tech/api-tracker/backend/services/identity-service/migrations"
 	_ "github.com/lib/pq"
 	"github.com/pressly/goose/v3"
 )
@@ -84,9 +85,9 @@ func runMigrations(db *sql.DB, logger *slog.Logger) error {
 	if err := goose.SetDialect("postgres"); err != nil {
 		return err
 	}
-	dir := "migrations"
-	logger.Info("running migrations", "dir", dir)
-	return goose.Up(db, dir)
+	goose.SetBaseFS(migrationsfs.FS)
+	logger.Info("running migrations")
+	return goose.Up(db, ".")
 }
 
 func mustEnv(key string) string {

--- a/backend/services/identity-service/migrations/embed.go
+++ b/backend/services/identity-service/migrations/embed.go
@@ -1,0 +1,6 @@
+package migrations
+
+import "embed"
+
+//go:embed *.sql
+var FS embed.FS


### PR DESCRIPTION
## Problem

Every pod start crashes with:
```
migrations failed: migrations directory does not exist
```

The Dockerfile final stage (`distroless/static`) only copies the compiled binary — the `migrations/` directory never makes it into the image.

## Fix

- Added `migrations/embed.go` with `//go:embed *.sql` — migration files are now compiled into the binary
- Updated `main.go` to call `goose.SetBaseFS(migrationsfs.FS)` before running migrations, reading from the embedded FS instead of the filesystem

No Dockerfile changes needed.

Closes #171