### PR TITLE
fix: strip /swagger/ prefix when proxying to swagger-ui

### DIFF
--- a/backend/api-gateway/nginx.conf
+++ b/backend/api-gateway/nginx.conf
@@ -46,6 +46,7 @@ http {
             return 301 /swagger/;
         }
         location /swagger/ {
+            rewrite ^/swagger/(.*)$ /$1 break;
             set $upstream swagger-ui:8080;
             proxy_pass http://$upstream;
             proxy_set_header Host $host;

--- a/deploy/helm/api-gateway/templates/configmap.yaml
+++ b/deploy/helm/api-gateway/templates/configmap.yaml
@@ -55,6 +55,7 @@ data:
                 return 301 /swagger/;
             }
             location /swagger/ {
+                rewrite ^/swagger/(.*)$ /$1 break;
                 set $upstream swagger-ui.{{ .Release.Namespace }}.svc.cluster.local:8080;
                 proxy_pass http://$upstream;
                 proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

- swagger-ui Docker image serves files from `/` (root), not from `/swagger/`
- nginx was proxying `/swagger/foo` → upstream gets `/swagger/foo` → swagger-ui returns 404
- Added `rewrite ^/swagger/(.*)$ /$1 break;` to strip prefix before proxying
- Updated both the Helm configmap (K8s) and local dev `nginx.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)