### PR TITLE
fix: remove /swagger/ prefix rewrite — proxy full path to swagger-ui

### DIFF
--- a/backend/api-gateway/nginx.conf
+++ b/backend/api-gateway/nginx.conf
@@ -46,7 +46,6 @@ http {
             return 301 /swagger/;
         }
         location /swagger/ {
-            rewrite ^/swagger/(.*)$ /$1 break;
             set $upstream swagger-ui:8080;
             proxy_pass http://$upstream;
             proxy_set_header Host $host;

--- a/deploy/helm/api-gateway/templates/configmap.yaml
+++ b/deploy/helm/api-gateway/templates/configmap.yaml
@@ -55,7 +55,6 @@ data:
                 return 301 /swagger/;
             }
             location /swagger/ {
-                rewrite ^/swagger/(.*)$ /$1 break;
                 set $upstream swagger-ui.{{ .Release.Namespace }}.svc.cluster.local:8080;
                 proxy_pass http://$upstream;
                 proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

- `BASE_PATH=/swagger` configures swagger-ui's internal nginx to serve at `/swagger/` (not at `/`)
- The `rewrite ^/swagger/(.*)$ /$1 break` stripped the prefix before proxying, so swagger-ui got `/` which didn't match its location block → 500
- Removed the rewrite: nginx now passes the full `/swagger/*` path through, which swagger-ui handles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)